### PR TITLE
fix: remove duplicate homepage meta description

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,10 +7,6 @@ export default function Index() {
 		<Layout pageType="home">
 			<Head>
 				<title>Acevedo Miguel - Cloud Architect & DevOps Engineer</title>
-				<meta
-					name="description"
-					content="Cloud Architect and DevOps Engineer with 20+ years of experience designing serverless, high-availability infrastructure across APAC. Delivering IoT solutions for the Japan energy market. Based in Hong Kong."
-				/>
 			</Head>
 			<Container>
 				<main id="main-content">


### PR DESCRIPTION
## Summary
- remove the extra `meta name=\"description\"` from `pages/index.tsx`
- keep homepage SEO description sourced from the shared SEO manager output
- prevent duplicate description tags in production HTML

## Test plan
- [x] Run `next lint` diagnostics for `pages/index.tsx`
- [x] Verify only one homepage `meta name=\"description\"` is emitted

Made with [Cursor](https://cursor.com)