### PR TITLE
feat: add GitLab link and refactor Areas of Expertise into shared component

### DIFF
--- a/components/area_expertise.tsx
+++ b/components/area_expertise.tsx
@@ -1,0 +1,44 @@
+export default function AreaExpertise() {
+  return (
+    <div>
+      <h2 id="expertise" className="text-xl font-semibold mb-4">
+									Areas of Expertise
+								</h2>
+
+								<div className="grid md:grid-cols-3 gap-6">
+									<div>
+										<h3 className="font-medium text-gray-900 mb-2">
+											Architectural Design
+										</h3>
+										<ul className="text-sm text-gray-600 space-y-1">
+											<li>Architectural Design</li>
+											<li>Event-Driven IoT Core</li>
+											<li>Multi-Region Resilience</li>
+										</ul>
+									</div>
+
+									<div>
+										<h3 className="font-medium text-gray-900 mb-2">
+											DevOps & Automation
+										</h3>
+										<ul className="text-sm text-gray-600 space-y-1">
+											<li>Zero-Touch CI/CD</li>
+											<li>Infrastructure as Code</li>
+											<li>Security Hardening</li>
+										</ul>
+									</div>
+
+									<div>
+										<h3 className="font-medium text-gray-900 mb-2">
+											Strategic Leadership
+										</h3>
+										<ul className="text-sm text-gray-600 space-y-1">
+											<li>Cloud Cost Optimization</li>
+											<li>Technical Governance</li>
+											<li>Modernization Roadmaps</li>
+										</ul>
+									</div>
+								</div>
+    </div>
+  );
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,5 +1,6 @@
 import {
 	FaGithub,
+	FaGitlab,
 	FaInstagram,
 	FaLinkedin,
 	FaMastodon,
@@ -34,6 +35,16 @@ export const Footer = () => {
 							>
 								<FaGithub className="react-icons" aria-hidden="true" />
 								<span className="sr-only">GitHub</span>
+							</a>
+							<a
+								href="https://gitlab.com/acevedomiguel/"
+								className="text-gray-500 hover:text-gray-900 dark:hover:text-white"
+								aria-label="Visit GitLab profile"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								<FaGitlab className="react-icons" aria-hidden="true" />
+								<span className="sr-only">GitLab</span>
 							</a>
 							<a
 								href="https://stackoverflow.com/users/599036/miguel-angel-acevedo"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/contact/index.tsx
+++ b/pages/contact/index.tsx
@@ -11,6 +11,7 @@ import {
 import Breadcrumbs from "../../components/Breadcrumbs";
 import Container from "../../components/container";
 import Layout from "../../components/layout";
+import AreaExpertise from "../../components/area_expertise";
 
 export default function Index() {
   const [copiedEmail, setCopiedEmail] = useState(false);
@@ -198,47 +199,7 @@ export default function Index() {
               className="mt-12 pt-8 border-t border-gray-200"
               aria-labelledby="expertise"
             >
-              <h2 id="expertise" className="text-xl font-semibold mb-4">
-                Areas of Expertise
-              </h2>
-
-              <div className="grid md:grid-cols-3 gap-6">
-                <div>
-                  <h3 className="font-medium text-gray-900 mb-2">
-                    DevOps & Infrastructure
-                  </h3>
-                  <ul className="text-sm text-gray-600 space-y-1" role="list">
-                    <li>AWS Cloud Architecture</li>
-                    <li>Kubernetes & Docker</li>
-                    <li>CI/CD Pipelines</li>
-                    <li>Infrastructure as Code</li>
-                  </ul>
-                </div>
-
-                <div>
-                  <h3 className="font-medium text-gray-900 mb-2">
-                    Backend Development
-                  </h3>
-                  <ul className="text-sm text-gray-600 space-y-1" role="list">
-                    <li>Node.js & TypeScript</li>
-                    <li>Python & Go</li>
-                    <li>Microservices Architecture</li>
-                    <li>API Design & GraphQL</li>
-                  </ul>
-                </div>
-
-                <div>
-                  <h3 className="font-medium text-gray-900 mb-2">
-                    IoT & Integration
-                  </h3>
-                  <ul className="text-sm text-gray-600 space-y-1" role="list">
-                    <li>IoT Device Integration</li>
-                    <li>MQTT & Message Queues</li>
-                    <li>Real-time Data Processing</li>
-                    <li>Edge Computing</li>
-                  </ul>
-                </div>
-              </div>
+              <AreaExpertise />
             </section>
           </article>
         </main>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import Container from "../components/container";
 import Layout from "../components/layout";
+import AreaExpertise from "../components/area_expertise";
 
 export default function Index() {
 	return (
@@ -81,47 +82,7 @@ export default function Index() {
 								className="mt-12 pt-8 border-t border-gray-200"
 								aria-labelledby="expertise"
 							>
-								<h2 id="expertise" className="text-xl font-semibold mb-4">
-									Areas of Expertise
-								</h2>
-
-								<div className="grid md:grid-cols-3 gap-6">
-									<div>
-										<h3 className="font-medium text-gray-900 mb-2">
-											DevOps & Infrastructure
-										</h3>
-										<ul className="text-sm text-gray-600 space-y-1">
-											<li>AWS Cloud Architecture</li>
-											<li>Kubernetes & Docker</li>
-											<li>CI/CD Pipelines</li>
-											<li>Infrastructure as Code</li>
-										</ul>
-									</div>
-
-									<div>
-										<h3 className="font-medium text-gray-900 mb-2">
-											Backend Development
-										</h3>
-										<ul className="text-sm text-gray-600 space-y-1">
-											<li>Node.js & TypeScript</li>
-											<li>Python & Go</li>
-											<li>Microservices Architecture</li>
-											<li>API Design & GraphQL</li>
-										</ul>
-									</div>
-
-									<div>
-										<h3 className="font-medium text-gray-900 mb-2">
-											IoT & Integration
-										</h3>
-										<ul className="text-sm text-gray-600 space-y-1">
-											<li>IoT Device Integration</li>
-											<li>MQTT & Message Queues</li>
-											<li>Real-time Data Processing</li>
-											<li>Edge Computing</li>
-										</ul>
-									</div>
-								</div>
+								<AreaExpertise />
 							</section>
 						</header>
 					</article>

--- a/pages/links/index.tsx
+++ b/pages/links/index.tsx
@@ -4,6 +4,7 @@ import Layout from "../../components/layout";
 import Container from "../../components/container";
 import {
 	FaGithub,
+	FaGitlab,
 	FaInstagram,
 	FaLinkedin,
 	FaStackOverflow,
@@ -23,6 +24,12 @@ const links = [
 		href: "https://github.com/acevedomiguel",
 		icon: FaGithub,
 		ariaLabel: "Visit GitHub profile",
+	},
+	{
+		name: "GitLab",
+		href: "https://gitlab.com/acevedomiguel/",
+		icon: FaGitlab,
+		ariaLabel: "Visit GitLab profile",
 	},
 	{
 		name: "Stack Overflow",

--- a/public/resume.json
+++ b/public/resume.json
@@ -1,7 +1,7 @@
 {
   "basics": {
     "name": "Acevedo Miguel",
-    "label": "Cloud Architect & DevOps Engineer",
+    "label": "Principal Cloud Architect | Founding Infrastructure Specialist",
     "image": "/profile.webp",
     "email": "me@acevedomiguel.com",
     "phone": "(+852) 6435-6936",


### PR DESCRIPTION
## Summary

- Add GitLab profile link (`https://gitlab.com/acevedomiguel/`) to the footer social nav and the `/links` page, using `FaGitlab` from `react-icons/fa` and matching existing accessibility/styling patterns.
- Extract the duplicated "Areas of Expertise" markup from `pages/index.tsx` and `pages/contact/index.tsx` into a new shared `components/area_expertise.tsx` component, and update the section content to better reflect current focus (Architectural Design, DevOps & Automation, Strategic Leadership).
- Update `public/resume.json` label to "Principal Cloud Architect | Founding Infrastructure Specialist".
- Sync `next-env.d.ts` routes reference path.

## Test plan

- [ ] Run `npm run dev` and verify the home page renders the new `AreaExpertise` component correctly.
- [ ] Verify the contact page renders the new `AreaExpertise` component correctly.
- [ ] Visit `/links` and confirm the GitLab pill button appears between GitHub and Stack Overflow and opens `https://gitlab.com/acevedomiguel/` in a new tab.
- [ ] Confirm the footer GitLab icon is visible on every page, has the correct hover/dark styling, and opens the GitLab profile in a new tab.
- [ ] Confirm screen reader output (`aria-label` / `sr-only`) for the new GitLab link.
- [ ] Run `npm run build` to ensure no type or lint regressions.

Made with [Cursor](https://cursor.com)